### PR TITLE
Fix for check-ntp.rb on older ntp versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=2.3.5
+VERSION=2.3.6
 TARGET=deb
 LOGLEVEL="warn"
 NAME=sensu-community-plugins

--- a/plugins/system/check-ntp.rb
+++ b/plugins/system/check-ntp.rb
@@ -41,8 +41,9 @@ class CheckNTP < Sensu::Plugin::Check::CLI
   def run
     begin
       output = `ntpq -c "rv 0 stratum,offset"`
-      stratum = output.split(',')[0].split('=')[1].strip.to_i
-      offset = output.split(',')[1].split('=')[1].strip.to_f
+      match_pattern = '^stratum=[0-9]+, offset=(\-)?[0-9]+'
+      stratum = /#{match_pattern}/.match(output).to_s.split(',')[0].split('=')[1].strip.to_i
+      offset = /#{match_pattern}/.match(output).to_s.split(',')[1].split('=')[1].strip.to_f
     rescue
       unknown 'NTP command Failed'
     end


### PR DESCRIPTION
- Ensure check-ntp.rb is compatible with output provided by ntp=4.2.4p4 provided by Debian Lenny
- Increase package version number
