### PR TITLE
Cherry-pick elasticsearch sensu-plugin to our own fork

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=2.3.6
+VERSION=2.3.7
 TARGET=deb
 LOGLEVEL="warn"
 NAME=sensu-community-plugins

--- a/plugins/elasticsearch/check-es-file-descriptors.rb
+++ b/plugins/elasticsearch/check-es-file-descriptors.rb
@@ -13,7 +13,6 @@
 #
 # DEPENDENCIES:
 #   gem: sensu-plugin
-#   gem: json
 #   gem: rest-client
 #
 # USAGE:
@@ -27,12 +26,14 @@
 #   for details.
 #
 
-require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/check/cli'
 require 'rest-client'
 require 'json'
 
-class ESClusterStatus < Sensu::Plugin::Check::CLI
+#
+# ES File Descriptiors
+#
+class ESFileDescriptors < Sensu::Plugin::Check::CLI
   option :host,
          description: 'Elasticsearch host',
          short: '-h HOST',
@@ -66,7 +67,7 @@ class ESClusterStatus < Sensu::Plugin::Check::CLI
          default: 80
 
   def get_es_resource(resource)
-    r = RestClient::Resource.new("http://#{config[:host]}:#{config[:port]}/#{resource}", timeout: config[:timeout])
+    r = RestClient::Resource.new("http://#{config[:host]}:#{config[:port]}#{resource}", timeout: config[:timeout])
     JSON.parse(r.get)
   rescue Errno::ECONNREFUSED
     warning 'Connection refused'
@@ -94,7 +95,7 @@ class ESClusterStatus < Sensu::Plugin::Check::CLI
     end
   end
 
-  def run
+  def run # rubocop:disable all
     open = acquire_open_fds
     max = acquire_max_fds
     used_percent = ((open.to_f / max.to_f) * 100).to_i

--- a/plugins/elasticsearch/check-es-heap.rb
+++ b/plugins/elasticsearch/check-es-heap.rb
@@ -26,11 +26,13 @@
 #   for details.
 #
 
-require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/check/cli'
 require 'rest-client'
 require 'json'
 
+#
+# ES Heap
+#
 class ESHeap < Sensu::Plugin::Check::CLI
   option :host,
          description: 'Elasticsearch host',
@@ -78,7 +80,7 @@ class ESHeap < Sensu::Plugin::Check::CLI
   end
 
   def acquire_es_resource(resource)
-    r = RestClient::Resource.new("http://#{config[:host]}:#{config[:port]}/#{resource}", timeout: config[:timeout])
+    r = RestClient::Resource.new("http://#{config[:host]}:#{config[:port]}#{resource}", timeout: config[:timeout])
     JSON.parse(r.get)
   rescue Errno::ECONNREFUSED
     warning 'Connection refused'
@@ -88,12 +90,12 @@ class ESHeap < Sensu::Plugin::Check::CLI
     warning 'Elasticsearch API returned invalid JSON'
   end
 
-  def acquire_heap_data(return_max = false)
+  def acquire_heap_data(return_max = false) # rubocop:disable all
     if Gem::Version.new(acquire_es_version) >= Gem::Version.new('1.0.0')
-      stats = acquire_es_resource('_nodes/_local/stats?jvm=true')
+      stats = acquire_es_resource('/_nodes/_local/stats?jvm=true')
       node = stats['nodes'].keys.first
     else
-      stats = acquire_es_resource('_cluster/nodes/_local/stats?jvm=true')
+      stats = acquire_es_resource('/_cluster/nodes/_local/stats?jvm=true')
       node = stats['nodes'].keys.first
     end
     begin
@@ -107,7 +109,7 @@ class ESHeap < Sensu::Plugin::Check::CLI
     end
   end
 
-  def run
+  def run # rubocop:disable all
     if config[:percentage]
       heap_used, heap_max = acquire_heap_data(true)
       heap_used_ratio = ((100 * heap_used) / heap_max).to_i

--- a/plugins/elasticsearch/metrics-es-cluster.rb
+++ b/plugins/elasticsearch/metrics-es-cluster.rb
@@ -16,7 +16,6 @@
 # DEPENDENCIES:
 #   gem: sensu-plugin
 #   gem: rest-client
-#   gem: json
 #
 # USAGE:
 #   #YELLOW
@@ -29,11 +28,13 @@
 #   for details.
 #
 
-require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/metric/cli'
 require 'rest-client'
 require 'json'
 
+#
+# ES Cluster Metrics
+#
 class ESClusterMetrics < Sensu::Plugin::Metric::CLI::Graphite
   option :scheme,
          description: 'Metric naming scheme, text to prepend to metric',
@@ -67,7 +68,7 @@ class ESClusterMetrics < Sensu::Plugin::Metric::CLI::Graphite
   end
 
   def get_es_resource(resource)
-    r = RestClient::Resource.new("http://#{config[:host]}:#{config[:port]}/#{resource}", timeout: config[:timeout])
+    r = RestClient::Resource.new("http://#{config[:host]}:#{config[:port]}#{resource}", timeout: config[:timeout])
     JSON.parse(r.get)
   rescue Errno::ECONNREFUSED
     warning 'Connection refused'


### PR DESCRIPTION
Cherry-pick elasticsearch sensu-plugin to our own fork of the old sensu-community-plugins repo.

  We need to go for this ugly hack until we have a plan for migrating to
  the new sensu-plugin-is-a-gem paradigm introduced recently in
  sensu-plugins that replaces the old sensu-community-plugins. See
  https://github.com/sensu-plugins/sensu-plugins-elasticsearch
