### PR TITLE
Change version to type string in logstash notifier

### DIFF
--- a/handlers/notification/logstash.rb
+++ b/handlers/notification/logstash.rb
@@ -49,7 +49,7 @@ class LogstashHandler < Sensu::Handler
     time = Time.now.utc.iso8601
     logstash_msg = {
       :@timestamp    => time,
-      :@version      => 1,
+      :@version      => "1",
       :source        => ::Socket.gethostname,
       :tags          => ["sensu-#{action_to_string}"],
       :message       => @event['check']['output'],


### PR DESCRIPTION
`@version` field uses to be a string, but this plugin is creating it with a numerical type, this can cause problems with elasticsearch and starting on 2.X indexes with this kind of incoherences don't work.

See https://www.elastic.co/blog/great-mapping-refactoring#conflicting-mappings

The error that appears in elastic wen trying to use an index with fields with same name but different types:

```
java.lang.IllegalStateException: unable to upgrade the mappings for the index [logstash-2017.02.02], reason: [mapper [@version] cannot be changed from type [string] to [long]]
``` 