### PR TITLE
Fixed message to show the right ceph osd hosts that are down

### DIFF
--- a/plugins/ceph/check-ceph-osd.rb
+++ b/plugins/ceph/check-ceph-osd.rb
@@ -212,7 +212,7 @@ class CheckCephOSDHealth < Sensu::Plugin::Check::CLI
       message = "OSDs down #{down_osds.round(2)}% - OSDs out #{out_osds.round(2)}%\n"
     elsif config[:per_host]
       osd_hosts.each do |host, values|
-        message = "Host: #{host} OSDs Down: #{values['percentage_down'].round(2)}%\n"
+        message += "Host: #{host} OSDs Down: #{values['percentage_down'].round(2)}%\n" if values['percentage_down'] > 0
       end
     end
 


### PR DESCRIPTION
Fixed message showed by the ceph plugin. It just showed the last host of the list.
With this PR, it shows all the hosts that have its OSD daemons down.