### PR TITLE
Fix consumer lag check

### DIFF
--- a/plugins/kafka/check-consumer-lag.rb
+++ b/plugins/kafka/check-consumer-lag.rb
@@ -125,8 +125,7 @@ class ConsumerLagCheck < Sensu::Plugin::Check::CLI
       topics_to_read.delete_if { |x| config[:topic_excludes].include?(x) } if config[:topic_excludes]
     end
 
-    cmd_offset = "#{kafka_run_class} kafka.tools.ConsumerOffsetChecker --group #{config[:group]} --zookeeper #{config[:zookeeper]}"
-    cmd_offset += " --topic #{topics_to_read.join(',')}" unless topics_to_read.empty?
+    cmd_offset = "#{kafka_run_class} kafka.admin.ConsumerGroupCommand --group #{config[:group]} --zookeeper #{config[:zookeeper]} --describe"
 
     topics = run_offset(cmd_offset).group_by { |h| h[:topic] }
 

--- a/plugins/kafka/check-consumer-lag.rb
+++ b/plugins/kafka/check-consumer-lag.rb
@@ -141,12 +141,12 @@ class ConsumerLagCheck < Sensu::Plugin::Check::CLI
         case over_or_under
         when :over
           if max_lag > threshold.to_i
-            msg = "Topics `#{max_topics}` for the group `#{group}` lag: #{max_lag} (>= #{threshold})"
+            msg = "Topics `#{max_topics}` for the group(s) `#{config[:groups]}` lag: #{max_lag} (>= #{threshold})"
             send severity, msg
           end
         when :under
           if min_lag < threshold.to_i
-            msg =  "Topics `#{min_topics}` for the group `#{group}` lag: #{min_lag} (<= #{threshold})"
+            msg =  "Topics `#{min_topics}` for the group(s) `#{config[:groups]}` lag: #{min_lag} (<= #{threshold})"
             send severity, msg
           end
         end


### PR DESCRIPTION
I have fixed the check because it was done for an older version and it has never worked properly in our kafka version. I have also updated the parameters to run against kafka nodes instead of using zookeeper, and removed parameters that weren't needed.