### PR TITLE
Improve etcd basic check.

### DIFF
--- a/plugins/etcd/check-etcd.rb
+++ b/plugins/etcd/check-etcd.rb
@@ -45,9 +45,44 @@ class EtcdNodeStatus < Sensu::Plugin::Check::CLI
          long: '--port PORT',
          default: '4001'
 
+  option :cert,
+         description: 'client SSL cert',
+         long: '--cert CERT',
+         default: nil
+
+  option :key,
+         description: 'client SSL key',
+         long: '--key KEY',
+         default: nil
+
+  option :passphrase,
+         description: 'passphrase of the SSL key',
+         long: '--passphrase PASSPHRASE',
+         default: nil
+
+  option :ca,
+         description: 'SSL CA file',
+         long: '--ca CA',
+         default: nil
+
+  option :insecure,
+         description: 'change SSL verify mode to false',
+         long: '--insecure'
+
+  option :ssl,
+         description: 'use HTTPS (default false)',
+         long: '--ssl'
+
   def run
-    r = RestClient::Resource.new("http://#{config[:server]}:#{config[:port]}/v2/stats/self", timeout: 5).get
-    if r.code == 200
+    protocol = config[:ssl] ? 'https' : 'http'
+    r = RestClient::Resource.new("#{protocol}://#{config[:server]}:#{config[:port]}/health",
+                                 timeout: 5,
+                                 ssl_client_cert: (OpenSSL::X509::Certificate.new(File.read(config[:cert])) unless config[:cert].nil?),
+                                 ssl_client_key: (OpenSSL::PKey::RSA.new(File.read(config[:key]), config[:passphrase]) unless config[:key].nil?),
+                                 ssl_ca_file:  config[:ca],
+                                 verify_ssl:  config[:insecure] ? 0 : 1).get
+    healthy = JSON.parse(r.to_str)['health']
+    if r.code == 200 && healthy
       ok 'etcd is up'
     else
       critical 'Etcd is not responding'


### PR DESCRIPTION
* Make the etcd check able to use SSL authentication when connecting to etcd member
* Use `/health` endpoint and check that response is `{"health": true}`